### PR TITLE
Add Prompt Thinking Loop Evaluator

### DIFF
--- a/prompt-evaluator/.github/workflows/deploy.yml
+++ b/prompt-evaluator/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy Streamlit App
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          cd prompt-evaluator
+          pip install -r requirements.txt
+      - name: Lint
+        run: echo "Lint step placeholder"
+      - name: Deploy
+        run: echo "Deploy step placeholder"

--- a/prompt-evaluator/README.md
+++ b/prompt-evaluator/README.md
@@ -1,0 +1,56 @@
+# Prompt Thinking Loop Evaluator
+
+This tool helps authors craft better prompts by analyzing them through four
+stages: **Ideate → Investigate → Iterate → Create**. It is built with a small
+heuristic engine and a Streamlit UI for quick feedback.
+
+## Features
+
+- Simple evaluation rules for each stage
+- Streamlit interface to type a prompt and view per‑stage feedback
+- Example prompts showing common mistakes
+- Documentation outlining architecture and rules
+
+## Installation
+
+1. Clone the repository.
+2. Navigate to the `prompt-evaluator` folder.
+3. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Usage
+
+Run the Streamlit application:
+
+```bash
+streamlit run app/main.py
+```
+
+Enter a prompt in the text area and click **Evaluate**. The app will display the
+result for each stage in expandable sections.
+
+## Folder Structure
+
+```
+prompt-evaluator/
+├── app/                # Streamlit UI
+├── logic/              # Evaluation logic
+├── examples/           # Sample prompts
+├── docs/               # Project documentation
+├── requirements.txt    # Python dependencies
+└── .github/workflows/  # CI/CD workflow (optional)
+```
+
+## Use Cases
+
+- Teaching prompt engineering concepts
+- Demonstrating iterative thinking when crafting prompts
+- Providing quick feedback for documentation writers
+
+## License
+
+This project is provided under the MIT license. See [LICENSE](../LICENSE) for
+details.

--- a/prompt-evaluator/app/main.py
+++ b/prompt-evaluator/app/main.py
@@ -1,0 +1,31 @@
+"""Streamlit application for the Prompt Thinking Loop Evaluator."""
+
+import streamlit as st
+from logic.evaluator import PromptEvaluator
+
+
+def main() -> None:
+    """Run the Streamlit UI."""
+    st.title("Prompt Thinking Loop Evaluator")
+    st.write("Analyze your prompt through the Ideate → Investigate → Iterate → Create loop.")
+
+    evaluator = PromptEvaluator()
+
+    prompt = st.text_area("Enter your prompt", height=200)
+    if st.button("Evaluate"):
+        if not prompt.strip():
+            st.warning("Please enter a prompt to evaluate.")
+            return
+
+        results = evaluator.evaluate(prompt)
+
+        for stage in evaluator.stages:
+            feedback = results[stage]
+            with st.expander(stage):
+                status = "✅ Passed" if feedback.passed else "❌ Failed"
+                st.markdown(f"**Result:** {status}")
+                st.write(feedback.feedback)
+
+
+if __name__ == "__main__":
+    main()

--- a/prompt-evaluator/docs/architecture.md
+++ b/prompt-evaluator/docs/architecture.md
@@ -1,0 +1,34 @@
+# Architecture Overview
+
+The Prompt Thinking Loop Evaluator is organized into a small set of modules to
+keep logic isolated from the user interface. The high‑level flow follows the
+four evaluation stages:
+
+```
+Prompt -> Ideate -> Investigate -> Iterate -> Create -> Results
+```
+
+## Components
+
+- **`logic/evaluator.py`**
+  Contains the heuristics for each stage. The `PromptEvaluator` returns detailed
+  feedback for the input prompt in the form of `StageFeedback` data classes.
+
+- **`app/main.py`**
+  Implements a Streamlit UI for entering prompts. It imports `PromptEvaluator`
+  from the logic layer and displays feedback for each stage using expanders.
+
+- **`examples/`**
+  Sample prompts used for testing and demonstration of failing cases.
+
+- **`docs/`**
+  This documentation folder describes the architecture and the rules that each
+  stage checks.
+
+## Reasoning Behind the Design
+
+The tool follows the typical pattern of separating presentation (Streamlit) from
+business logic. This makes it easier to update rules without changing the UI.
+The evaluator uses simple keyword matching so that it can run without external
+dependencies or network calls. Each stage can be expanded in the future with
+more sophisticated natural language processing.

--- a/prompt-evaluator/docs/prompt-rules.md
+++ b/prompt-evaluator/docs/prompt-rules.md
@@ -1,0 +1,15 @@
+# Prompt Rules
+
+Each stage in the Prompt Thinking Loop checks for specific attributes in a
+prompt. When a rule is triggered, the evaluator marks the stage as failed and
+returns a short explanation.
+
+| Stage | Trigger | Explanation |
+|-------|---------|-------------|
+| **Ideate** | Prompt shorter than 10 characters or phrased as a question | Indicates the goal is unclear or not well defined. |
+| **Investigate** | Absence of words like `context`, `research`, or `background` | Shows that no research or prior information is referenced. |
+| **Iterate** | Missing keywords `revise`, `iterate`, `refine`, or `feedback` | The prompt does not encourage improving or refining the output. |
+| **Create** | No verbs such as `create`, `generate`, `produce`, or `write` | The prompt does not specify what should be produced. |
+
+These rules can be extended with more sophisticated natural language checks as
+the project evolves.

--- a/prompt-evaluator/examples/test_prompts.md
+++ b/prompt-evaluator/examples/test_prompts.md
@@ -1,0 +1,24 @@
+# Example Problematic Prompts
+
+The following prompts intentionally violate different stages of the Prompt Thinking Loop.
+Each example includes the expected stage that fails and a short explanation.
+
+1. **"Help?"**
+   - *Fails:* Ideate
+   - *Reason:* The request is too short and lacks a clear goal.
+
+2. **"Write something."**
+   - *Fails:* Investigate
+   - *Reason:* There is no background or research context provided.
+
+3. **"Create a report."**
+   - *Fails:* Iterate
+   - *Reason:* No mention of revision or refinement steps.
+
+4. **"Can you check if this makes sense?"**
+   - *Fails:* Create
+   - *Reason:* The prompt does not specify a tangible deliverable.
+
+5. **"Tell me about research methods?"**
+   - *Fails:* Iterate and Create
+   - *Reason:* It includes investigation but lacks iteration cues and deliverable instructions.

--- a/prompt-evaluator/logic/evaluator.py
+++ b/prompt-evaluator/logic/evaluator.py
@@ -1,0 +1,105 @@
+"""Prompt Thinking Loop Evaluator logic.
+
+This module defines the evaluator for analyzing prompts using the
+Ideate → Investigate → Iterate → Create loop. Each stage has a
+set of simple heuristics to determine whether the prompt sufficiently
+addresses that phase.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class StageFeedback:
+    """Holds evaluation result for a single stage."""
+
+    stage: str
+    passed: bool
+    feedback: str
+
+
+class PromptEvaluator:
+    """Evaluates prompts based on the Prompt Thinking Loop."""
+
+    stages: List[str] = ["Ideate", "Investigate", "Iterate", "Create"]
+
+    def __init__(self) -> None:
+        pass
+
+    def evaluate(self, prompt: str) -> Dict[str, StageFeedback]:
+        """Evaluate the given prompt.
+
+        Parameters
+        ----------
+        prompt : str
+            The user provided prompt.
+
+        Returns
+        -------
+        Dict[str, StageFeedback]
+            Mapping of stage name to feedback.
+        """
+        prompt_lower = prompt.lower()
+        results: Dict[str, StageFeedback] = {}
+
+        # Ideate: prompt should communicate a clear idea or goal
+        if len(prompt.strip()) < 10 or "?" in prompt:
+            results["Ideate"] = StageFeedback(
+                stage="Ideate",
+                passed=False,
+                feedback="Prompt lacks a clear goal or is too short."
+            )
+        else:
+            results["Ideate"] = StageFeedback(
+                stage="Ideate",
+                passed=True,
+                feedback="Clear goal identified."
+            )
+
+        # Investigate: should reference context or mention research
+        if any(word in prompt_lower for word in ["context", "research", "background"]):
+            results["Investigate"] = StageFeedback(
+                stage="Investigate",
+                passed=True,
+                feedback="Includes context or research hints."
+            )
+        else:
+            results["Investigate"] = StageFeedback(
+                stage="Investigate",
+                passed=False,
+                feedback="No investigation or context found."
+            )
+
+        # Iterate: should encourage refinement or iteration
+        if any(word in prompt_lower for word in ["revise", "iterate", "refine", "feedback"]):
+            results["Iterate"] = StageFeedback(
+                stage="Iterate",
+                passed=True,
+                feedback="Mentions iteration or refinement."
+            )
+        else:
+            results["Iterate"] = StageFeedback(
+                stage="Iterate",
+                passed=False,
+                feedback="No sign of iteration or refinement."
+            )
+
+        # Create: should request generation or final deliverable
+        if any(word in prompt_lower for word in ["create", "generate", "produce", "write"]):
+            results["Create"] = StageFeedback(
+                stage="Create",
+                passed=True,
+                feedback="Specifies a deliverable."
+            )
+        else:
+            results["Create"] = StageFeedback(
+                stage="Create",
+                passed=False,
+                feedback="Does not specify what to create."
+            )
+
+        return results
+
+
+__all__ = ["PromptEvaluator", "StageFeedback"]

--- a/prompt-evaluator/requirements.txt
+++ b/prompt-evaluator/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+typing


### PR DESCRIPTION
## Summary
- scaffold a new `prompt-evaluator` tool
- implement evaluator logic and Streamlit UI
- document architecture, rules, and example prompts
- add requirements and CI/CD workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687333f803248322872292fd871cc647