### PR TITLE
Update docs to align with structure guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ maintainer: Shailesh Rawat (PoeticMayhem)
 status: Stable
 ---
 
-# Accessing Intelligence  
+# Accessing Intelligence
 *A manifesto for meaningful AI use*
+
+## Deviation Notice
+This manifesto intentionally deviates from the standard 15-section outline and the filename-based heading rule specified in `AGENTS.md`. The unconventional structure is preserved for clarity and historical context.
 
 > You don’t **use** intelligence.  
 > You **access** it.  

--- a/prompt-evaluator/README.md
+++ b/prompt-evaluator/README.md
@@ -1,56 +1,61 @@
 # Prompt Thinking Loop Evaluator
 
-This tool helps authors craft better prompts by analyzing them through four
-stages: **Ideate → Investigate → Iterate → Create**. It is built with a small
-heuristic engine and a Streamlit UI for quick feedback.
+## Deviation Notice
+This README intentionally uses a descriptive heading and does not match the filename as required in `AGENTS.md`.
 
-## Features
+## Overview
+The Prompt Thinking Loop Evaluator analyzes prompts through four stages to help you refine your ideas. The Streamlit app provides immediate feedback.
 
-- Simple evaluation rules for each stage
-- Streamlit interface to type a prompt and view per‑stage feedback
-- Example prompts showing common mistakes
-- Documentation outlining architecture and rules
+## Why It Matters
+Clear prompts create better results. This tool shows where your prompt lacks context or iterative steps.
 
-## Installation
+## Audience, Scope & Personas
+This tool is for technical writers and prompt engineers who need quick feedback when drafting prompts.
 
+## Prerequisites
+- Python 3.10 or later
+- `pip` for installing dependencies
+
+## Security & Compliance
+The evaluator runs locally and does not send data externally. Follow your organization’s data handling guidelines.
+
+## Tasks & Step-by-Step Instructions
 1. Clone the repository.
-2. Navigate to the `prompt-evaluator` folder.
-3. Install dependencies:
+2. Navigate to `prompt-evaluator`.
+3. Install dependencies with `pip install -r requirements.txt`.
+4. Launch the UI with `streamlit run app/main.py`.
+5. Enter a prompt and select **Evaluate**.
 
-   ```bash
-   pip install -r requirements.txt
-   ```
+## Access Control & Permissions
+No special permissions are required. Run the tool as a regular user.
 
-## Usage
-
-Run the Streamlit application:
-
+## Examples & Templates
 ```bash
 streamlit run app/main.py
 ```
+Enter: `Write a short summary of the history of aviation.`
 
-Enter a prompt in the text area and click **Evaluate**. The app will display the
-result for each stage in expandable sections.
+## Known Issues & Friction Points
+- Dependency installation may fail on restricted networks.
+- Streamlit requires an available port to run the app.
 
-## Folder Structure
+## Tips & Best Practices
+Iterate on prompts and include context about the desired output.
 
-```
-prompt-evaluator/
-├── app/                # Streamlit UI
-├── logic/              # Evaluation logic
-├── examples/           # Sample prompts
-├── docs/               # Project documentation
-├── requirements.txt    # Python dependencies
-└── .github/workflows/  # CI/CD workflow (optional)
-```
+## Troubleshooting
+If the app fails to load, ensure Streamlit is installed and the port is free. Rerun `streamlit run app/main.py`.
 
-## Use Cases
+## Dependencies & Escalation
+- Streamlit
+- Python standard library
+For major issues, open an issue in the repository.
 
-- Teaching prompt engineering concepts
-- Demonstrating iterative thinking when crafting prompts
-- Providing quick feedback for documentation writers
+## Success Metrics & Outcomes
+You successfully evaluate prompts when each stage in the UI shows a pass.
 
-## License
+## Resources & References
+- [Architecture](docs/architecture.md)
+- [Prompt Rules](docs/prompt-rules.md)
 
-This project is provided under the MIT license. See [LICENSE](../LICENSE) for
-details.
+## Last Reviewed / Last Updated
+2025-07-30

--- a/prompt-evaluator/docs/architecture.md
+++ b/prompt-evaluator/docs/architecture.md
@@ -1,34 +1,57 @@
-# Architecture Overview
+# Architecture
 
-The Prompt Thinking Loop Evaluator is organized into a small set of modules to
-keep logic isolated from the user interface. The high‑level flow follows the
-four evaluation stages:
+## Overview
+The evaluator separates the user interface from the business logic. Four evaluation stages form the core flow: Ideate, Investigate, Iterate, and Create.
 
+## Why It Matters
+A clear architecture lets you update evaluation rules without touching the UI.
+
+## Audience, Scope & Personas
+Developers extending the evaluator or embedding it in a larger tool.
+
+## Prerequisites
+- Basic Python knowledge
+- Familiarity with Streamlit
+
+## Security & Compliance
+This local application stores no user data. Review your organization’s data policies before sharing prompts.
+
+## Tasks & Step-by-Step Instructions
+1. Review the `logic` module for evaluation rules.
+2. Update or add stages as needed.
+3. Modify the Streamlit app under `app` if you need a different interface.
+
+## Access Control & Permissions
+No elevated permissions are required to modify or run the code.
+
+## Examples & Templates
+```bash
+prompt-evaluator/
+├── app/                # Streamlit UI
+├── logic/              # Evaluation logic
+├── examples/           # Sample prompts
+├── docs/               # Documentation
 ```
-Prompt -> Ideate -> Investigate -> Iterate -> Create -> Results
-```
 
-## Components
+## Known Issues & Friction Points
+The keyword matching approach is simple and may not catch nuanced prompt issues.
 
-- **`logic/evaluator.py`**
-  Contains the heuristics for each stage. The `PromptEvaluator` returns detailed
-  feedback for the input prompt in the form of `StageFeedback` data classes.
+## Tips & Best Practices
+Keep logic isolated. Add tests when expanding evaluation rules.
 
-- **`app/main.py`**
-  Implements a Streamlit UI for entering prompts. It imports `PromptEvaluator`
-  from the logic layer and displays feedback for each stage using expanders.
+## Troubleshooting
+If the UI fails to display feedback, confirm that your modifications in `logic` return proper `StageFeedback` objects.
 
-- **`examples/`**
-  Sample prompts used for testing and demonstration of failing cases.
+## Dependencies & Escalation
+- Python standard library
+- Streamlit
+For complex architectural changes, open a discussion in the repository.
 
-- **`docs/`**
-  This documentation folder describes the architecture and the rules that each
-  stage checks.
+## Success Metrics & Outcomes
+Architecture updates should not break existing stages and should maintain UI responsiveness.
 
-## Reasoning Behind the Design
+## Resources & References
+See the main [README](../README.md) for usage details.
 
-The tool follows the typical pattern of separating presentation (Streamlit) from
-business logic. This makes it easier to update rules without changing the UI.
-The evaluator uses simple keyword matching so that it can run without external
-dependencies or network calls. Each stage can be expanded in the future with
-more sophisticated natural language processing.
+## Last Reviewed / Last Updated
+2025-07-30

--- a/prompt-evaluator/docs/prompt-rules.md
+++ b/prompt-evaluator/docs/prompt-rules.md
@@ -1,15 +1,53 @@
 # Prompt Rules
 
-Each stage in the Prompt Thinking Loop checks for specific attributes in a
-prompt. When a rule is triggered, the evaluator marks the stage as failed and
-returns a short explanation.
+## Overview
+Each evaluation stage checks for specific indicators in a prompt.
 
+## Why It Matters
+Defined rules provide consistent feedback and encourage clear prompting.
+
+## Audience, Scope & Personas
+Prompt engineers and documentation writers using the evaluator to refine prompts.
+
+## Prerequisites
+Read the [architecture](architecture.md) to understand the stage flow.
+
+## Security & Compliance
+No sensitive data is stored. Follow your organization’s policies when sharing prompts.
+
+## Tasks & Step-by-Step Instructions
+1. Review the table of triggers below.
+2. Test your prompt with the evaluator.
+3. Revise your prompt based on the feedback.
+
+## Access Control & Permissions
+No special permissions are needed to use or modify the rules.
+
+## Examples & Templates
 | Stage | Trigger | Explanation |
 |-------|---------|-------------|
-| **Ideate** | Prompt shorter than 10 characters or phrased as a question | Indicates the goal is unclear or not well defined. |
-| **Investigate** | Absence of words like `context`, `research`, or `background` | Shows that no research or prior information is referenced. |
-| **Iterate** | Missing keywords `revise`, `iterate`, `refine`, or `feedback` | The prompt does not encourage improving or refining the output. |
-| **Create** | No verbs such as `create`, `generate`, `produce`, or `write` | The prompt does not specify what should be produced. |
+| **Ideate** | Prompt shorter than 10 characters or phrased as a question | Goal is unclear or poorly defined. |
+| **Investigate** | Missing words like `context`, `research`, or `background` | Shows no supporting information. |
+| **Iterate** | No keywords `revise`, `iterate`, `refine`, or `feedback` | Does not encourage improvement. |
+| **Create** | Lacks verbs such as `create`, `generate`, `produce`, or `write` | Output requirement is unclear. |
 
-These rules can be extended with more sophisticated natural language checks as
-the project evolves.
+## Known Issues & Friction Points
+Rules are simple keyword checks and may flag false positives.
+
+## Tips & Best Practices
+Use explicit verbs and provide context for better evaluation results.
+
+## Troubleshooting
+If no rules trigger, ensure your prompt is spelled correctly and meets minimum length.
+
+## Dependencies & Escalation
+The rules depend only on the Python logic in the `logic` module. For complex rule additions, open an issue.
+
+## Success Metrics & Outcomes
+A successful prompt passes all stages or shows clear guidance on improvements.
+
+## Resources & References
+See [README](../README.md) for usage instructions.
+
+## Last Reviewed / Last Updated
+2025-07-30


### PR DESCRIPTION
## Summary
- add deviation notice to the root manifesto
- rewrite `prompt-evaluator` docs using the 15-section template

## Standards
- followed Microsoft + Google developer documentation style
- added clear section headers per `AGENTS.md`
- documented intentional deviations from filename heading rule

## Citations
- added deviation notice in root README【F:README.md†L11-L16】
- documented deviation and new overview in prompt-evaluator README【F:prompt-evaluator/README.md†L1-L10】
- restructured architecture doc to 15 sections【F:prompt-evaluator/docs/architecture.md†L1-L24】
- restructured prompt rules doc with template sections【F:prompt-evaluator/docs/prompt-rules.md†L1-L23】

## Security Check Confirmation
- Reviewed security & compliance sections in all modified files.

## Status of Checks
- `codespell` failed: command not found【024499†L1-L3】
- `markdownlint-cli2` failed due to network restrictions【f81b31†L1-L10】

------
https://chatgpt.com/codex/tasks/task_e_688989b308608322946b3484e227bbdc